### PR TITLE
Update links naar gitdocumentatie

### DIFF
--- a/communities/kennisplatform-apis/index.md
+++ b/communities/kennisplatform-apis/index.md
@@ -23,10 +23,10 @@ De verschillende onderdelen van de NL API Strategie bevatten de volgende documen
 | Algemeen | [Inleiding NL API Strategie](https://geonovum.github.io/KP-APIs/API-strategie-algemeen/Inleiding/) |
 | Algemeen | 	[Architectuur NL API Strategie](https://geonovum.github.io/KP-APIs/API-strategie-algemeen/Architectuur/) |
 | Algemeen | [Gebruikerswensen NL API Strategie](https://geonovum.github.io/KP-APIs/API-strategie-algemeen/Gebruikerswensen/) |
-| Normatief | [API Design Rules (ADR)](https://publicatie.centrumvoorstandaarden.nl/api/adr/) |
+| Normatief | [API Design Rules (ADR)](https://gitdocumentatie.logius.nl/publicatie/api/adr/) |
 | Normatief | [Open API Specification (OAS)](https://forumstandaardisatie.nl/open-standaarden/openapi-specification) |
-| Normatief | [NL GOV OAuth profiel](https://publicatie.centrumvoorstandaarden.nl/api/oauth/) |
-| Normatief | [Digikoppeling REST API koppelvlak specificatie](https://publicatie.centrumvoorstandaarden.nl/dk/restapi/) |
+| Normatief | [NL GOV OAuth profiel](https://gitdocumentatie.logius.nl/publicatie/api/oauth/) |
+| Normatief | [Digikoppeling REST API koppelvlak specificatie](https://gitdocumentatie.logius.nl/publicatie/dk/restapi/) |
 | Functionele module | [GEO module](https://docs.geostandaarden.nl/api/API-Strategie-mod-geo/) |
 | Technische module | [Transport Security module](https://geonovum.github.io/KP-APIs/API-strategie-modules/transport-security/) |
 | Technische module | [Access control module](https://geonovum.github.io/KP-APIs/API-strategie-modules/access-control/) |


### PR DESCRIPTION
De centrumvoorstandaarden.nl server werkt niet meer en alle documenten zijn beschikbaar via gitdocumentatie.logius.nl