### PR TITLE
Maak sectie over WCAG iets completer

### DIFF
--- a/docs/frontend/standaarden/digitoegankelijk.md
+++ b/docs/frontend/standaarden/digitoegankelijk.md
@@ -18,15 +18,15 @@ Dit artikel heeft als doel om developers ondersteuning te bieden bij het impleme
 
 Sinds 1 juli 2018 zijn overheidsorganisaties verplicht [zich te houden](https://www.forumstandaardisatie.nl/open-standaarden/digitoegankelijk-en-301-549-met-wcag-21) aan de [WCAG 2.1](https://www.w3.org/TR/WCAG21/) richtlijnen. Dit om te zorgen dat zoveel mogelijk Nederlandse burgers, ook mensen met een beperking gebruik kunnen maken van overheidsdiensten.
 
-## Toegankelijkheid voor Iedereen
+## Toegankelijkheid voor iedereen
 
 Burgers kunnen bijvoorbeeld te maken hebben met **permanente functiebeperkingen**:
 
-- dyslexie
-- kleurenblindheid
-- slechthorendheid
-- slechtziendheid
+- slechthorendheid en doofheid
+- lichtgevoeligheid, slechtziendheid en blindheid
+- spraakbeperkingen
 - motorische beperkingen
+- cognitieve beperkingen
 
 Naast permanente functiebeperkingen kunnen gebruikers ook te kampen hebben met:
 
@@ -37,10 +37,9 @@ De WCAG 2.1 bevat verschillende succescriteria die aansluiten bij de genoemde be
 
 De WCAG 2.1 dient toegepast te worden op:
 
-- Websites (HTML, JS)
-- Single Page Applications (HTML, JS)
-- Documenten (PDF)
-- Android/ iOS of andere mobiele apps
+- Websites, waaronder Single Page Applications (HTML, CSS, JS)
+- Documenten (PDF, Word, Excel)
+- Mobiele apps (zoals op iOS en Android)
 
 ## Drie WCAG-niveaus van naleving (A, AA, AAA)
 

--- a/docs/frontend/standaarden/digitoegankelijk.md
+++ b/docs/frontend/standaarden/digitoegankelijk.md
@@ -37,8 +37,8 @@ De WCAG 2.1 bevat verschillende succescriteria die aansluiten bij de genoemde be
 
 De WCAG 2.1 dient toegepast te worden op:
 
-- Websites, waaronder Single Page Applications (HTML, CSS, JS)
-- Documenten (PDF, Word, Excel)
+- Websites, waaronder Single Page Applications (denk aan HTML, CSS, SVG, JavaScript)
+- Documenten (zoals PDF, Word, Excel)
 - Mobiele apps (zoals op iOS en Android)
 
 ## Drie WCAG-niveaus van naleving (A, AA, AAA)


### PR DESCRIPTION
Twee aanpassingen: 

- lijstje beperkingen direct overgnomen uit [abstract van WCAG](https://www.w3.org/TR/WCAG22/#abstract) om nog wat preciezer overeen te komen qua scope; dyslexie en kleurenblindheid zitten daar niet in, cognitieve beperkingen juist weer wel
- Single Page Apps en websites samengevoegt en CSS aan de technieken toegevoegd
- Word en Excel ook toegevoegd als voorbeelden van documenten