### PR TITLE
Update informatie over conformiteitsniveaus

### DIFF
--- a/docs/frontend/standaarden/digitoegankelijk.md
+++ b/docs/frontend/standaarden/digitoegankelijk.md
@@ -18,15 +18,15 @@ Dit artikel heeft als doel om developers ondersteuning te bieden bij het impleme
 
 Sinds 1 juli 2018 zijn overheidsorganisaties verplicht [zich te houden](https://www.forumstandaardisatie.nl/open-standaarden/digitoegankelijk-en-301-549-met-wcag-21) aan de [WCAG 2.1](https://www.w3.org/TR/WCAG21/) richtlijnen. Dit om te zorgen dat zoveel mogelijk Nederlandse burgers, ook mensen met een beperking gebruik kunnen maken van overheidsdiensten.
 
-## Toegankelijkheid voor iedereen
+## Toegankelijkheid voor Iedereen
 
 Burgers kunnen bijvoorbeeld te maken hebben met **permanente functiebeperkingen**:
 
-- slechthorendheid en doofheid
-- lichtgevoeligheid, slechtziendheid en blindheid
-- spraakbeperkingen
+- dyslexie
+- kleurenblindheid
+- slechthorendheid
+- slechtziendheid
 - motorische beperkingen
-- cognitieve beperkingen
 
 Naast permanente functiebeperkingen kunnen gebruikers ook te kampen hebben met:
 
@@ -37,24 +37,20 @@ De WCAG 2.1 bevat verschillende succescriteria die aansluiten bij de genoemde be
 
 De WCAG 2.1 dient toegepast te worden op:
 
-- Websites, waaronder Single Page Applications (denk aan HTML, CSS, SVG, JavaScript)
-- Documenten (zoals PDF, Word, Excel)
-- Mobiele apps (zoals op iOS en Android)
+- Websites (HTML, JS)
+- Single Page Applications (HTML, JS)
+- Documenten (PDF)
+- Android/ iOS of andere mobiele apps
 
 ## Drie WCAG-niveaus van naleving (A, AA, AAA)
 
-De in totaal 78 successcriteria die zijn opgenomen in WCAG 2.1 zijn allemaal verbonden aan een conformiteits-niveau. De drie niveaus die WCAG onderscheidt, zijn:
+Elk van de 78 successcriteria in WCAG 2.1 heeft een conformiteits-niveau, en websites kunnen verklaren tot op welk niveau ze voldoen. De drie niveaus die WCAG onderscheidt, zijn:
 
-- Niveau A (laagste niveau)
-  - Makkelijkst toe te passen, meeste impact voor de gebruiker
-  - Bevat 30 succescriteria van niveau A
-  - Deze criteria zijn het gemakkelijkst om aan te voldoen en hebben minimale impact op de structuur en vormgeving van een website.
-- Niveau AA
-  - Bevat 20 succescriteria van niveau AA
-  - Aan deze criteria is moeilijker te voldoen. Het stelt bijvoorbeeld hoge eisen aan het contrast tussen tekst en achtergrond. Ook eist het van je dat HTML-elementen die in-focus zijn een duidelijke actieve status hebben met bijvoorbeeld een border.
-- Niveau AAA (hoogste niveau)
-  - Bevat 28 succescriteria van niveau AAA
-  - Niveau AAA stelt nog hogere eisen. Zo is het bijvoorbeeld verplicht videomateriaal aan te bieden met gebarentolk.
+- Niveau A (laagste niveau), 30 succescriteria
+- Niveau AA, 20 succescriteria
+- Niveau AAA (hoogste niveau), 28 succescriteria
+ 
+In Nederland is het voor overheden verplicht om te voldoen tot niveau AA. Op niveau AAA kun je het beste per criterium inschatten of mogelijk is om te voldoen.
 
 ## Correct HTML-gebruik voor toegankelijkheid
 

--- a/docs/frontend/standaarden/digitoegankelijk.md
+++ b/docs/frontend/standaarden/digitoegankelijk.md
@@ -18,7 +18,7 @@ Dit artikel heeft als doel om developers ondersteuning te bieden bij het impleme
 
 Sinds 1 juli 2018 zijn overheidsorganisaties verplicht [zich te houden](https://www.forumstandaardisatie.nl/open-standaarden/digitoegankelijk-en-301-549-met-wcag-21) aan de [WCAG 2.1](https://www.w3.org/TR/WCAG21/) richtlijnen. Dit om te zorgen dat zoveel mogelijk Nederlandse burgers, ook mensen met een beperking gebruik kunnen maken van overheidsdiensten.
 
-## Toegankelijkheid voor Iedereen
+## Toegankelijkheid voor iedereen
 
 Burgers kunnen bijvoorbeeld te maken hebben met **permanente functiebeperkingen**:
 


### PR DESCRIPTION
De informatie die er stond was goed bedoeld, maar in WCAG wordt niet echt duidelijk onderscheid gemaakt wat betreft de betekenis van elk niveau. Het toebedelen van een criterium aan een niveau gebeurd op basis van een aantal criteria en met behulp van het consensusproces, lange discussies in werkgroepen dus.

Bron: https://yatil.net/blog/wcags-a-and-aa-distinction-is-mostly-academic 

Het is dus veiliger om niet teveel over elk niveau te zeggen.