### PR TITLE
Sta bouwen toe op pull request

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,10 @@
 name: Build & Link Check
 
-on: push
+on:
+  pull_request:
+  push:
+      branches:
+        - main
     
 jobs:
   build-site:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,8 +3,6 @@ name: Build & Link Check
 on:
   pull_request:
   push:
-      branches:
-        - main
     
 jobs:
   build-site:
@@ -66,7 +64,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
-          push: true
+          push: ${{ github.event_name != 'pull_request' }}
           target: serve
           tags: |
             ghcr.io/developer-overheid-nl/don-site:latest


### PR DESCRIPTION
Hiermee kunnen pull requests worden gebouwd, ongeacht of deze van interne of externe contributors komen. Voor externe contributors moet bij de eerste pull request wel goedkeuring worden verleend door een maintainer, om misbruik te voorkomen.