### PR TITLE
Revamp build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,8 +21,8 @@ jobs:
         with:
           target: caddy
           tags: |
-            ${IMAGE_NAME}:latest
-            ${IMAGE_NAME}:${{ github.sha }}
+            $IMAGE_NAME:latest
+            $IMAGE_NAME:${{ github.sha }}
           outputs: type=docker,dest=${{ runner.temp }}/image.tar
 
       - name: Upload artifact
@@ -57,4 +57,4 @@ jobs:
 
       - name: Push image
         run: |
-          docker push --all-tags ${IMAGE_NAME}
+          docker push --all-tags $IMAGE_NAME

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Build image
         uses: docker/build-push-action@v6
         with:
-          target: caddy
+          target: serve
           tags: |
             ${{ env.IMAGE_NAME }}:latest
             ${{ env.IMAGE_NAME }}:${{ github.sha }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Build image
         uses: docker/build-push-action@v6
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,69 +1,60 @@
-name: Build & Link Check
+name: Build
 
-on: push
-    
+on:
+  push:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: "Branch name."
+        required: true
+        default: "main"
+
+env:
+  IMAGE_NAME: ghcr.io/developer-overheid-nl/don-site
+
 jobs:
-  build-site:
+  build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - name: Build image
+        uses: docker/build-push-action@v6
+        with:
+          target: caddy
+          tags: |
+            ${IMAGE_NAME}:latest
+            ${IMAGE_NAME}:${{ github.sha }}
+          outputs: type=docker,dest=${{ runner.temp }}/image.tar
 
-      - name: Install pnpm
-        run: npm install -g pnpm
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Build Docusaurus site
-        run: npm run build
-
-      - name: Upload build artifact
+      - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: docusaurus-build
-          path: build
+          name: image
+          path: ${{ runner.temp }}/image.tar
 
-  check-links:
+  publish:
+    if: |
+      github.organization == 'developer-overheid-nl' &&
+      (github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-latest
-    needs: build-site
+    needs: build
     steps:
-      - uses: actions/checkout@v4
-
-      - name: Download build artifact
+      - name: Download artifact
         uses: actions/download-artifact@v4
         with:
-          name: docusaurus-build
-          path: build
+          name: image
+          path: ${{ runner.temp }}
 
-      - name: Run Linkinator to check external links
-        uses: JustinBeckwith/linkinator-action@v1
-        continue-on-error: true
-        with:
-          paths: "build"
-          recurse: true
-          config: "./linkinator.config.json"
-          verbosity: "ERROR"
-          timeout: 5000
-          retry: 3
+      - name: Load image
+        run: |
+          docker load --input ${{ runner.temp }}/image.tar
 
-  build-and-push:
-    runs-on: ubuntu-latest
-    permissions:
-      packages: write
-    steps:
-      - uses: actions/checkout@v4
       - name: Login to container registry
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Build & push Docker image
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          push: true
-          target: serve
-          tags: |
-            ghcr.io/developer-overheid-nl/don-site:latest
-            ghcr.io/developer-overheid-nl/don-site:${{ github.sha }}
+
+      - name: Push image
+        run: |
+          docker push --all-tags ${IMAGE_NAME}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,6 +33,7 @@ jobs:
         with:
           name: image
           path: ${{ runner.temp }}/image.tar
+          retention-days: 1
 
   publish:
     if: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,8 +21,8 @@ jobs:
         with:
           target: caddy
           tags: |
-            $IMAGE_NAME:latest
-            $IMAGE_NAME:${{ github.sha }}
+            ${{ env.IMAGE_NAME }}:latest
+            ${{ env.IMAGE_NAME }}:${{ github.sha }}
           outputs: type=docker,dest=${{ runner.temp }}/image.tar
 
       - name: Upload artifact
@@ -57,4 +57,4 @@ jobs:
 
       - name: Push image
         run: |
-          docker push --all-tags $IMAGE_NAME
+          docker push --all-tags ${{ env.IMAGE_NAME }}

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -1,0 +1,31 @@
+name: Check external links
+
+on:
+  schedule:
+    - cron: "0 5 * * *"
+
+jobs:
+  check-links:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install pnpm
+        run: npm install -g pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build Docusaurus site
+        run: pnpm run build
+
+      - name: Run Linkinator to check external links
+        uses: JustinBeckwith/linkinator-action@v1
+        continue-on-error: true
+        with:
+          paths: "build"
+          recurse: true
+          config: "./linkinator.config.json"
+          verbosity: "ERROR"
+          timeout: 5000
+          retry: 3


### PR DESCRIPTION
Fixes https://github.com/developer-overheid-nl/don-infra/issues/19.

Aanpassingen:
- Link checker is losgetrokken naar een scheduled job die dagelijks om 5:00 (UTC) draait.
- Build and publish stappen zijn uit elkaar getrokken in 2 aparte jobs (binnen dezelfde workflow).
- De workflow runt voor alle push operaties en voor manuele workflow dispatches
- De build job maakt enkel gebruik van de Docker build (voorheen werd de `pnpm build` meerdere malen gedraaid)
- De publish job runt conditioneel, standaard alleen:
  - wanneer de build job slaagt
  - op de DON org (dus niet in een fork) 
  - op de main branch
- Als men een image wil publishen van een andere branch, dan kan dit gedaan worden dmv een manuele workflow dispatch.

