### PR TITLE
Fix line endings in Git

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text eol=lf


### PR DESCRIPTION
Om te voorkomen dat artikelen met CRLF worden geschreven