### PR TITLE
docs: tweak omschrijving en link naar pleio community

### DIFF
--- a/communities/digitoegankelijk.md
+++ b/communities/digitoegankelijk.md
@@ -1,10 +1,6 @@
 ---
 tags:
-  - "accessibility"
   - "wcag"
-  - "toegankelijkheid"
-  - "wetgeving"
-  - "en 301 549"
 title: "DigiToegankelijk"
 ---
 


### PR DESCRIPTION
- omschrijving aangepast naar de taakstelling van DT
- enkele relevante tags toegevoegd voor betere vindbaarheid
- link naar Pleio community toegevoegd
- 'naar de website van' uit linktekst gehaald (`<filofische-stem>`gaan _alle_ links niet naar een website?)