### PR TITLE
docs: voeg Pleio community toe en leg uit wanneer welke community

### DIFF
--- a/docs/leidraad/toegankelijk-en-inclusief/index.md
+++ b/docs/leidraad/toegankelijk-en-inclusief/index.md
@@ -4,7 +4,7 @@ sidebar_position: 2
 tags: ["accessibility"]
 ---
 
-Toegankelijkheid zorgt ervoor dat iedereen, inclusief mensen met een beperking, overheidsdiensten digitaal kan gebruiken. Dit is niet alleen een wettelijke verplichting (zoals de Europese **Webrichtlijnen** en de **Wet digitale overheid**), maar ook essentieel voor inclusieve dienstverlening.
+Toegankelijkheid zorgt ervoor dat iedereen, inclusief mensen met een beperking, overheidsdiensten digitaal kan gebruiken. Dit is niet alleen een wettelijke verplichting (zoals het [**Besluit Digitale Toegankelijkheid Overheid**](https://wetten.overheid.nl/BWBR0040936/2018-07-01)), maar ook essentieel voor inclusieve dienstverlening.
 
 ## Belangrijke redenen
 
@@ -14,7 +14,8 @@ Toegankelijkheid zorgt ervoor dat iedereen, inclusief mensen met een beperking, 
 
 ## Communities
 
-- [NL Design System](/communities/nl-design-system)
+- [DigiToegankelijk Pleio](/communities/digitoegankelijk#community) (om informatie uit te wisselen over de wettelijke verplichtingen en organisatorische aanpak)
+- [NL Design System](/communities/nl-design-system) (om samen te werken aan de praktische invulling, zoals redactie, ontwerp en code)
 
 ## Standaarden
 


### PR DESCRIPTION
Aantal fixes: 

- “Europese Webrichtlijnen” bestaan niet; er is het Web Accessibility Directive, iets dat uit Europa komt en in elke lidstaat geïmplementeerd wordt, in Nederland is dat in de BDTO gebeurd; heb daar nu 1 link van gemaakt
- DigiToegankelijk community op Pleio toegevoegd en uitgelegd wanneer je welke nodig hebt (NL Design System of Pleio)