### PR TITLE
Add underline to all links

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -112,6 +112,7 @@
   --ifm-color-content: #0f172a;
 
   --ifm-link-color: var(--ifm-color-primary);
+  --ifm-link-decoration: underline;
 
   --ifm-navbar-height: auto;
   --ifm-navbar-shadow: none;
@@ -197,10 +198,6 @@ html {
 
 .alert a {
   --ifm-alert-border-color: var(--ifm-color-gray-700);
-}
-
-.markdown p a, .markdown li a, .markdown table a {
-  --ifm-link-decoration: underline;
 }
 
 @media (min-width: 90rem) { /* 1440px */


### PR DESCRIPTION
Currently Axe reports WCAG issues for all tag overview pages:

```
WCAG issues found on: https://developer.overheid.nl/kennisbank/tags/golang
  Violation of "link-in-text-block" with 1 occurrences!
    Ensure links are distinguished from surrounding text in a way that does not rely on color. Correct invalid elements at:
    For details, see: https://dequeuniversity.com/rules/axe/4.10/link-in-text-block
1 Accessibility issues detected.
```

These links currently don't have an underline, despite other links do have underlines. By configuring this variable in the root, it is applied to all links.