### PR TITLE
Add links to Rust tools and getting started docs

### DIFF
--- a/docs/programmeertalen/rust/index.mdx
+++ b/docs/programmeertalen/rust/index.mdx
@@ -81,8 +81,7 @@ misbruiken om beheerdersrechten te krijgen.
 
 Omdat Rust een jonge taal is zijn er minder packages voor handen dan
 bijvoorbeeld in Python of in Java. Een voorbeeld hiervan noemt ook de Kiesraad
-in het
-[interview dat we met haar hielden](https://developer.overheid.nl/blog/2025/03/26/interview-kiesraad-rust#een-jonger-ecosysteem-betekent-minder-uitgebreide-libraries-voor-legacy-standaarden-bijvoorbeeld-xml).
+in het [interview dat we met haar hielden][kiesraad-interview].
 In het interview komt naar voren dat de libraries die er zijn, niet altijd even
 volwassen of uitgebouwd zijn. Ze noemen bijvoorbeeld de library `quick-xml` voor
 het verwerken van XML en zeggen hierover:
@@ -90,6 +89,9 @@ het verwerken van XML en zeggen hierover:
 "Je merkt dat de meest gebruikte XML library voor Rust (quick-xml) wel voldoet,
 maar minder volwassen en uitgebreid is dan wat je in andere talen vindt.
 Bijvoorbeeld in Java of .NET, die zijn ontwikkeld toen XML in opkomst was."
+
+[kiesraad-interview]:
+https://developer.overheid.nl/blog/2025/03/26/interview-kiesraad-rust#een-jonger-ecosysteem-betekent-minder-uitgebreide-libraries-voor-legacy-standaarden-bijvoorbeeld-xml
 
 ### 2. Steile learning curve
 


### PR DESCRIPTION
Add links to Rust tools and getting started docs as a follow-up to #422