### PR TITLE
chore: documentatie verbreden met nlds en rhc informatie

### DIFF
--- a/docs/front-end/index.mdx
+++ b/docs/front-end/index.mdx
@@ -7,15 +7,71 @@ import { Card } from "@rijkshuisstijl-community/components-react";
 
 # Front-end
 
-Front-end development draait om de ontwikkeling van de gebruikersinterface van websites en webapplicaties.
+Front-end development draait om de ontwikkeling van de gebruikersinterface van
+websites en webapplicaties.
+
+Binnen de overheid is digitale dienstverlening de standaard geworden. Dit
+betekent dat veel organisaties zelf een website of webapplicatie moeten bouwen
+om hun diensten aan te bieden. Om dubbel werk te voorkomen is de NL design
+system community opgericht. Hiermee kunnen publieke organisaties samenwerken aan
+herbruikbare componenten en sneller eigen design systemen opzetten die voldoen
+aan toegankelijkheidseisen.
+
+## NL Design System en het Estafette model
+
+Het [NL Design System](https://nldesignsystem.nl/) is een **framework** waarmee
+organisaties hun eigen design system kunnen bouwen. Het belangrijkste voordeel
+is dat componenten die zijn gebouwd met dit framework eenvoudig kunnen worden
+uitgewisseld tussen verschillende design systems. Door middel van design tokens
+worden white-label componenten voorzien van een eigen huisstijl, waardoor
+dezelfde componentcode herbruikbaar is voor meerdere organisaties.
+
+Het Estafette model staat centraal in NL Design System: teams ontwikkelen
+componenten die anderen kunnen hergebruiken en verbeteren. Door samen te werken
+aan herbruikbare componenten maken we het mogelijk om over organisatiegrenzen
+heen consistentie en kwaliteit te bereiken en standaarden te creëren.
+
+Als je zelf een publieke organisatie bent, en je wilt een design systeem
+opzetten is dit waar je wilt beginnen.
+
+### Rijkshuisstijl Community
+
+De [Rijkshuisstijl Community](https://rijkshuisstijl.community/) is een
+opensource community die een **concrete implementatie** van de Rijkshuisstijl
+heeft ontwikkeld als design system componenten. Een van de vele design systemen
+die is aangesloten bij het NL Design System framework.
+
+**Het verschil:** Waar NL Design System het framework is om een design system te
+bouwen, biedt Rijkshuisstijl Community direct bruikbare componenten die al zijn
+vormgegeven volgens de Rijkshuisstijl. Dit maakt het eenvoudiger om snel aan de
+slag te gaan met projecten die de Rijkshuisstijl moeten volgen.
+
+Als je zelf geen design system wilt opzetten, maar snel wilt bouwen met
+componenten die voldoen aan de Rijkshuisstijl, dan is dit de plek om te
+beginnen.
+
+### Op de hoogte blijven
+
+- Praat mee op [Slack van Code for NL](https://praatmee.codefor.nl) in het
+  kanaal #nl-design-system. hier vind je ook de Rijkshuisstijl Community
+  developers.
+- Bezoek de tweewekelijkse NL Design System Heartbeat meetings
+- Sluit je aan bij de
+  [Rijkshuisstijl Community op GitHub](https://github.com/Rijkshuisstijl)
+- Sluit aan bij de wekelijkse
+  [developers meeting van de Rijkshuisstijl Community](https://nldesignsystem.nl/events/developer-open-hour/overzicht/)
+- Schrijf je in voor de nieuwsbrief via
+  [Gebruiker Centraal](https://www.gebruikercentraal.nl/)
 
 ## Bronnen
 
 - [DigiToegankelijk](https://www.digitoegankelijk.nl/)
 - [Gebruiker Centraal](https://www.gebruikercentraal.nl/)
 - [NL-Design-System](https://nldesignsystem.nl/)
+- [Rijkshuisstijl Community](https://rijkshuisstijl.community/)
 
 ## Aan de slag!
+
 <Grid>
   <Card
     appearance="default"
@@ -25,22 +81,29 @@ Front-end development draait om de ontwikkeling van de gebruikersinterface van w
     linkLabel="Naar de tutorial"
   />
 
-  <Card
-    appearance="default"
-    description="Monitor je project continu op de WCAG-toegankelijkheidseisen."
-    heading="Voeg een Github action toe voor accessibility"
-    href="./standaarden/digitoegankelijk/run-axe"
-    linkLabel="Voeg een Github action toe"
-  />
+<Card
+  appearance="default"
+  description="Wil je snel bouwen met rijkshuisstijl componenten? Volg dan deze tutorial."
+  heading="Getting started: Rijkshuisstijl Community"
+  href="https://rijkshuisstijl-community.vercel.app/?path=/docs/react-components-readme--docs"
+  linkLabel="React componenten docs"
+/>
+
+<Card
+  appearance="default"
+  description="Monitor je project continu op de WCAG-toegankelijkheidseisen."
+  heading="Voeg een Github action toe voor accessibility"
+  href="./standaarden/digitoegankelijk/run-axe"
+  linkLabel="Voeg een Github action toe"
+/>
 
   <Card
-    appearance="default" 
+    appearance="default"
     heading="Werken met geodata en LeafletJS"
     description="Gemeente Amsterdam biedt een developer omgeving met code examples."
     href="./maps-developers-amsterdam"
     linkLabel="Naar het artikel"
   />
-
 </Grid>
 
 <br />


### PR DESCRIPTION
de Frontend documentatie pagina geupdate en een bredere focus gelegd op het NDLS en RHC. 