### PR TITLE
Update Docker linter command to include OAS_URL_OR_FILE

### DIFF
--- a/docs/apis/api-design-rules/api-design-rules-linter.md
+++ b/docs/apis/api-design-rules/api-design-rules-linter.md
@@ -45,7 +45,7 @@ $ code
 ```bash
 $ docker run --rm --entrypoint=sh \
     -v $(pwd)/api:/locale stoplight/spectral:5.9.1 \
-    -c "spectral lint -r https://static.developer.overheid.nl/adr/ruleset.yaml"
+    -c "spectral lint -r https://static.developer.overheid.nl/adr/ruleset.yaml $OAS_URL_OR_FILE"
 ```
 
 ## GitLab


### PR DESCRIPTION
The Docker example was missing a placeholder.