### PR TITLE
Ondersteuning voor aangepast icoon via customProps in DocCard

### DIFF
--- a/src/theme/DocCard/index.tsx
+++ b/src/theme/DocCard/index.tsx
@@ -125,7 +125,10 @@ function CardCategory({ item }: { item: PropSidebarItemCategory }): ReactNode {
 }
 
 function CardLink({ item }: { item: PropSidebarItemLink }): ReactNode {
-  const icon = isInternalUrl(item.href) ? (
+  const customIcon = item.customProps?.icon as string | undefined;
+  const icon = customIcon ? (
+    <img src={customIcon} className={styles.cardIcon} alt="" aria-hidden="true" />
+  ) : isInternalUrl(item.href) ? (
     <IconDocumentMetVlakkenEnLijnenErop className={styles.cardIcon} />
   ) : (
     <IconKetting2Schakels className={styles.cardIcon} />

--- a/src/theme/DocCard/styles.module.css
+++ b/src/theme/DocCard/styles.module.css
@@ -32,3 +32,7 @@
   width: 2rem;
   vertical-align: bottom;
 }
+
+img.cardIcon {
+  object-fit: contain;
+}


### PR DESCRIPTION
## Wat doet deze wijziging?
Voegt de mogelijkheid toe om een aangepast icoon te tonen op een `DocCard` via `sidebar_custom_props` in de frontmatter van een documentiepagina. Het gaat hier om de functionaliteit — als er een betere of andere manier is om dit te voor elkaar te krijgen / implementeren, dan zou dat uiteraard ook mooi zijn.

## Gebruik
Voeg de mogelijkheid toe om een icon-property in te stellen met `sidebar_custom_props` in de frontmatter van een .md-bestand:

```markdown
---
sidebar_custom_props:
  icon: /img/mijn-services/icons/mijn-taken.svg
---
```

Het opgegeven icoon wordt dan getoond op de bijbehorende kaart in de documentatieoverzichtspagina.

## Gewijzigde bestanden
 * `index.tsx` — leest `item.customProps?.icon` uit en toont een `<img>` als dit aanwezig is, als fallback wordt het standaard icoon gebruikt
 * `styles.module.css` — voegt `object-fit: contain` toe voor het img-element zodat het icoon correct wordt weergegeven

## Screenshots

<img width="2294" height="1245" alt="Schermafbeelding 2026-04-05 114158" src="https://github.com/user-attachments/assets/94cc12d0-08a1-43ce-a519-d3ad6c5e2075" />






