### PR TITLE
Publiceer deel 3: zes uitdagingen bij schema-ontwerp

### DIFF
--- a/.changeset/publish-graphql-deel-3.md
+++ b/.changeset/publish-graphql-deel-3.md
@@ -1,0 +1,5 @@
+---
+"@developer-overheid-nl/website": minor
+---
+
+Publish GraphQL blog series part 3

--- a/blog/2026/07/30-graphql-1-introductie.md
+++ b/blog/2026/07/30-graphql-1-introductie.md
@@ -256,18 +256,18 @@ caching, autorisatie en beheersing van de belasting.
 
 ## De rest van deze serie
 
-<!-- TODO: bij publicatie van deel 3 en 4 hier telkens de link naar het
-verschenen deel toevoegen -->
+<!-- TODO: bij publicatie van deel 4 hier de link naar het verschenen deel
+toevoegen -->
 
 In de komende delen gaan we de diepte in:
 
 - **[Deel 2](/blog/2026/08/18/graphql-2-flexibiliteit-en-limieten)** behandelt
   de kernbelofte van GraphQL (flexibel bevragen als oplossing voor over- en
   underfetching) en de prijs die daar tegenover staat: onvoorspelbare
-  performance en een groter aanvalsoppervlak, en hoe je daar limieten aan
-  stelt.
-- **Deel 3** duikt in de praktijk van schema-ontwerp: paginering, filtering,
-  union types, custom scalars, autorisatie en content negotiation.
+  performance en een groter aanvalsoppervlak, en hoe je daar limieten aan stelt.
+- **[Deel 3](/blog/2026/08/26/graphql-3-schema-ontwerp)** duikt in de praktijk
+  van schema-ontwerp: paginering, filtering, union types, custom scalars,
+  autorisatie en content negotiation.
 - **Deel 4** brengt alles samen in een afwegingskader: wanneer is GraphQL een
   logische keuze, en wanneer ben je met REST beter af, zeker binnen de context
   van de Nederlandse overheid en de ADR.

--- a/blog/2026/08/18-graphql-2-flexibiliteit-en-limieten.md
+++ b/blog/2026/08/18-graphql-2-flexibiliteit-en-limieten.md
@@ -33,7 +33,7 @@ samenstellen? En vooral: hoe stel je daar grenzen aan?
 
 <!-- truncate -->
 
-<!-- TODO bij publicatie: deel 3 en 4 linken zodra die delen verschenen zijn -->
+<!-- TODO bij publicatie: deel 4 linken zodra dat deel verschenen is -->
 
 :::info[GraphQL onder de loep]
 
@@ -41,7 +41,7 @@ Dit artikel is deel 2 van een vierdelige serie:
 
 1. [Een kennismaking](/blog/2026/07/30/graphql-1-introductie)
 2. Flexibel bevragen, en wat dat kost (dit deel)
-3. Zes uitdagingen bij schema-ontwerp (volgt)
+3. [Zes uitdagingen bij schema-ontwerp](/blog/2026/08/26/graphql-3-schema-ontwerp)
 4. Wanneer wel, en wanneer niet? (volgt)
 
 :::
@@ -329,7 +329,7 @@ inzet, plant depth limiting, cost analysis, monitoring per operatie en een
 cachingstrategie daarom in als onderdeel van de basisinrichting, niet als
 optimalisatie achteraf.
 
-In deel 3 <!-- TODO: linken zodra deel 3 is gepubliceerd --> verleggen we de
-blik van runtime naar design-time: wat komt er kijken bij het ontwerpen van een
-goed GraphQL-schema, en waarom blijkt dat in de praktijk lastiger dan de
-voorbeelden doen vermoeden?
+In [deel 3](/blog/2026/08/26/graphql-3-schema-ontwerp) verleggen we de blik van
+runtime naar design-time: wat komt er kijken bij het ontwerpen van een goed
+GraphQL-schema, en waarom blijkt dat in de praktijk lastiger dan de voorbeelden
+doen vermoeden?

--- a/blog/2026/08/26-graphql-3-schema-ontwerp.md
+++ b/blog/2026/08/26-graphql-3-schema-ontwerp.md
@@ -1,5 +1,4 @@
 ---
-draft: true
 authors: [joost-farla]
 tags:
   [api, api-design, graphql, rest, interoperabiliteit, standaarden, geodata]
@@ -16,26 +15,25 @@ description: |
 
 ![GraphQL onder de loep](/img/graphql-onder-de-loep.jpg)
 
-In [deel 2](/blog/draft/graphql-2-flexibiliteit-en-limieten) <!-- TODO: link
-bijwerken na publicatie --> zagen we dat de flexibiliteit van GraphQL een beheeropgave
-met zich meebrengt. In dit deel kijken we naar de ontwerpkant. De rode draad: veel
-zaken die je in REST oplost met mechanismen van HTTP (headers, statuscodes, media
-types, middleware op routes) moeten in GraphQL expliciet gemodelleerd worden in het
-schema en de resolvers. Dat maakt schema's en queries complexer dan de voorbeelden
-uit deel 1 doen vermoeden. We behandelen zes uitdagingen die je in vrijwel elk GraphQL-project
-van enige omvang tegenkomt.
+In [deel 2](/blog/2026/08/18/graphql-2-flexibiliteit-en-limieten) zagen we dat
+de flexibiliteit van GraphQL een beheeropgave met zich meebrengt. In dit deel
+kijken we naar de ontwerpkant. De rode draad: veel zaken die je in REST oplost
+met mechanismen van HTTP (headers, statuscodes, media types, middleware op
+routes) moeten in GraphQL expliciet gemodelleerd worden in het schema en de
+resolvers. Dat maakt schema's en queries complexer dan de voorbeelden uit deel 1
+doen vermoeden. We behandelen zes uitdagingen die je in vrijwel elk
+GraphQL-project van enige omvang tegenkomt.
 
 <!-- truncate -->
 
-<!-- TODO bij publicatie: link van deel 2 omzetten naar de definitieve URL;
-deel 4 linken zodra dat deel verschenen is -->
+<!-- TODO bij publicatie: deel 4 linken zodra dat deel verschenen is -->
 
 :::info[GraphQL onder de loep]
 
 Dit artikel is deel 3 van een vierdelige serie:
 
 1. [Een kennismaking](/blog/2026/07/30/graphql-1-introductie)
-2. [Flexibel bevragen, en wat dat kost](/blog/draft/graphql-2-flexibiliteit-en-limieten)
+2. [Flexibel bevragen, en wat dat kost](/blog/2026/08/18/graphql-2-flexibiliteit-en-limieten)
 3. Zes uitdagingen bij schema-ontwerp (dit deel)
 4. Wanneer wel, en wanneer niet? (volgt)
 

--- a/blog/draft/graphql-4-afwegingskader.md
+++ b/blog/draft/graphql-4-afwegingskader.md
@@ -19,11 +19,10 @@ In de eerste drie delen van deze serie hebben we GraphQL leren kennen als een
 getypeerde querytaal met een fundamenteel ander model dan REST
 ([deel 1](/blog/2026/07/30/graphql-1-introductie)), zagen we dat de flexibele
 bevraging zowel de grote kracht als een serieuze beheeropgave is
-([deel 2](/blog/draft/graphql-2-flexibiliteit-en-limieten)) en liepen we zes
-ontwerpuitdagingen langs die in de praktijk bepalen hoeveel werk een GraphQL-API
-werkelijk kost ([deel 3](/blog/draft/graphql-3-schema-ontwerp)).
-
-<!-- TODO: links naar deel 2 en 3 bijwerken na publicatie -->
+([deel 2](/blog/2026/08/18/graphql-2-flexibiliteit-en-limieten)) en liepen we
+zes ontwerpuitdagingen langs die in de praktijk bepalen hoeveel werk een
+GraphQL-API werkelijk kost
+([deel 3](/blog/2026/08/26/graphql-3-schema-ontwerp)).
 
 In dit slotdeel komen we bij de vraag waar het allemaal om draait: wanneer is
 GraphQL een passende keuze, en wanneer ben je met REST beter af? Er zijn
@@ -31,16 +30,13 @@ omstandigheden waarin het ene model aantoonbaar beter past dan het andere.
 
 <!-- truncate -->
 
-<!-- TODO bij publicatie: de links naar deel 2 en 3 omzetten naar de
-definitieve URL's -->
-
 :::info[GraphQL onder de loep]
 
 Dit artikel is deel 4 van een vierdelige serie:
 
 1. [Een kennismaking](/blog/2026/07/30/graphql-1-introductie)
-2. [Flexibel bevragen, en wat dat kost](/blog/draft/graphql-2-flexibiliteit-en-limieten)
-3. [Zes uitdagingen bij schema-ontwerp](/blog/draft/graphql-3-schema-ontwerp)
+2. [Flexibel bevragen, en wat dat kost](/blog/2026/08/18/graphql-2-flexibiliteit-en-limieten)
+3. [Zes uitdagingen bij schema-ontwerp](/blog/2026/08/26/graphql-3-schema-ontwerp)
 4. Wanneer wel, en wanneer niet? (dit deel)
 
 :::


### PR DESCRIPTION
Deel 3 van de GraphQL-serie, gepland op woensdag 26 augustus 2026.

Alleen mergen is genoeg: bestand op zijn definitieve plek, draft-vlag eraf, serielinks bijgewerkt, changeset (minor) erbij.

Deel 2 is inmiddels via #866 gepubliceerd op 18 augustus. Deze branch is daarom opnieuw opgebouwd bovenop `main`: de eerdere deel 2-commit is vervallen, de basis staat niet langer op `graphql-deel-2` en alle serielinks wijzen nu naar de definitieve URL's.