### PR TITLE
Publiceer deel 4: wanneer wel, en wanneer niet?

### DIFF
--- a/.changeset/publish-graphql-deel-4.md
+++ b/.changeset/publish-graphql-deel-4.md
@@ -1,0 +1,5 @@
+---
+"@developer-overheid-nl/website": minor
+---
+
+Publish GraphQL blog series part 4

--- a/blog/2026/07/30-graphql-1-introductie.md
+++ b/blog/2026/07/30-graphql-1-introductie.md
@@ -256,9 +256,6 @@ caching, autorisatie en beheersing van de belasting.
 
 ## De rest van deze serie
 
-<!-- TODO: bij publicatie van deel 4 hier de link naar het verschenen deel
-toevoegen -->
-
 In de komende delen gaan we de diepte in:
 
 - **[Deel 2](/blog/2026/08/18/graphql-2-flexibiliteit-en-limieten)** behandelt
@@ -268,9 +265,10 @@ In de komende delen gaan we de diepte in:
 - **[Deel 3](/blog/2026/08/26/graphql-3-schema-ontwerp)** duikt in de praktijk
   van schema-ontwerp: paginering, filtering, union types, custom scalars,
   autorisatie en content negotiation.
-- **Deel 4** brengt alles samen in een afwegingskader: wanneer is GraphQL een
-  logische keuze, en wanneer ben je met REST beter af, zeker binnen de context
-  van de Nederlandse overheid en de ADR.
+- **[Deel 4](/blog/2026/09/02/graphql-4-afwegingskader)** brengt alles samen in
+  een afwegingskader: wanneer is GraphQL een logische keuze, en wanneer ben je
+  met REST beter af, zeker binnen de context van de Nederlandse overheid en de
+  ADR.
 
 Een compacte referentie over GraphQL, met de status binnen de overheid en de
 belangrijkste specificaties, staat in de

--- a/blog/2026/08/18-graphql-2-flexibiliteit-en-limieten.md
+++ b/blog/2026/08/18-graphql-2-flexibiliteit-en-limieten.md
@@ -33,8 +33,6 @@ samenstellen? En vooral: hoe stel je daar grenzen aan?
 
 <!-- truncate -->
 
-<!-- TODO bij publicatie: deel 4 linken zodra dat deel verschenen is -->
-
 :::info[GraphQL onder de loep]
 
 Dit artikel is deel 2 van een vierdelige serie:
@@ -42,7 +40,7 @@ Dit artikel is deel 2 van een vierdelige serie:
 1. [Een kennismaking](/blog/2026/07/30/graphql-1-introductie)
 2. Flexibel bevragen, en wat dat kost (dit deel)
 3. [Zes uitdagingen bij schema-ontwerp](/blog/2026/08/26/graphql-3-schema-ontwerp)
-4. Wanneer wel, en wanneer niet? (volgt)
+4. [Wanneer wel, en wanneer niet?](/blog/2026/09/02/graphql-4-afwegingskader)
 
 :::
 

--- a/blog/2026/08/26-graphql-3-schema-ontwerp.md
+++ b/blog/2026/08/26-graphql-3-schema-ontwerp.md
@@ -26,8 +26,6 @@ GraphQL-project van enige omvang tegenkomt.
 
 <!-- truncate -->
 
-<!-- TODO bij publicatie: deel 4 linken zodra dat deel verschenen is -->
-
 :::info[GraphQL onder de loep]
 
 Dit artikel is deel 3 van een vierdelige serie:
@@ -35,7 +33,7 @@ Dit artikel is deel 3 van een vierdelige serie:
 1. [Een kennismaking](/blog/2026/07/30/graphql-1-introductie)
 2. [Flexibel bevragen, en wat dat kost](/blog/2026/08/18/graphql-2-flexibiliteit-en-limieten)
 3. Zes uitdagingen bij schema-ontwerp (dit deel)
-4. Wanneer wel, en wanneer niet? (volgt)
+4. [Wanneer wel, en wanneer niet?](/blog/2026/09/02/graphql-4-afwegingskader)
 
 :::
 
@@ -333,7 +331,5 @@ een krachtig, generiek bevragingsmodel en vraagt in ruil daarvoor dat je
 conventies die REST van HTTP en van standaarden als de ADR cadeau krijgt, zelf
 ontwerpt, bouwt en bewaakt. Daarmee is de vraag niet óf GraphQL werkt (dat doet
 het aantoonbaar, ook op grote schaal), maar wanneer die opgave in verhouding
-staat tot wat het oplevert. Dat is het onderwerp van deel 4, het slot van deze
-serie.
-
-<!-- TODO: deel 4 linken zodra dat is gepubliceerd -->
+staat tot wat het oplevert. Dat is het onderwerp van
+[deel 4](/blog/2026/09/02/graphql-4-afwegingskader), het slot van deze serie.

--- a/blog/2026/09/02-graphql-4-afwegingskader.md
+++ b/blog/2026/09/02-graphql-4-afwegingskader.md
@@ -1,5 +1,4 @@
 ---
-draft: true
 authors: [joost-farla]
 tags: [api, api-design, graphql, rest, adr, adoptie, orkestratie, fsc]
 image: /img/graphql-onder-de-loep.jpg


### PR DESCRIPTION
Deel 4 van de GraphQL-serie, gepland op woensdag 2 september 2026. Hiermee is de serie compleet.

Alleen mergen is genoeg: bestand op zijn definitieve plek, draft-vlag eraf, alle serielinks compleet, changeset (minor) erbij. Na deze PR staan er geen publicatie-TODO's meer in de serie.

Gestapeld op #858. Merge die eerst; deze PR gaat daarna automatisch naar `main`.
